### PR TITLE
Update RoleController.php: fix: php max function

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2893,7 +2893,9 @@ class RoleController extends Controller
                 ->pluck('category_id')
                 ->all();
             $reservedIds = array_unique(array_merge($previousJsonIds, $historicalCustomIds));
-            $nextSafeId = (int) max(99, ...$reservedIds) + 1;
+            //old: $nextSafeId = (int) max(99, ...$reservedIds) + 1;
+            //bug: https://php-changed-behaviors.readthedocs.io/en/latest/behavior/maxOnEmpty.html
+            $nextSafeId = (int) (empty($reservedIds) ? 100 : max(99, ...$reservedIds) + 1);
             $usedInPayload = [];
 
             // Lookup of the OLD entries by id, used to preserve `name_en` across saves when the


### PR DESCRIPTION
fix: php max function does not work with an empty array
//bug: https://php-changed-behaviors.readthedocs.io/en/latest/behavior/maxOnEmpty.html